### PR TITLE
fix: add missing compute_features export in features module

### DIFF
--- a/analysis/features/__init__.py
+++ b/analysis/features/__init__.py
@@ -52,3 +52,6 @@ def compute_instance_features(instances: Iterable[Instance]) -> pd.DataFrame:
         rows.append(row)
 
     return pd.concat(rows)
+
+# Export the compute_features function that's imported in __main__.py
+compute_features = compute_instance_features


### PR DESCRIPTION
This PR fixes a missing export in the features module that was causing the analysis tools to fail.

The issue:
- `__main__.py` imports `compute_features` from `analysis.features`
- But this function was not exported in `features/__init__.py`

The fix:
- Add `compute_features = compute_instance_features` export in `features/__init__.py`

This allows the CLI tools to work as intended.