### PR TITLE
Add resolution count to dataset

### DIFF
--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -34,32 +34,26 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
     viz_project = viz_client.create_project(
         name="SWE-bench Leaderboard",
         view={
-            "elements": [
-                {
-                    "type": "markdown",
-                    "content": {"type": "data", "field": "problem_statement"}
-                },
-                {
-                    "type": "vstack",
-                    "elements": [
-                        {
-                            "type": "text",
-                            "content": {"type": "output", "field": "status"},
-                            "label": "Status"
-                        },
-                        {
-                            "type": "code",
-                            "content": {"type": "output", "field": "patch"},
-                            "label": "Generated Patch"
-                        },
-                        {
-                            "type": "code",
-                            "content": {"type": "data", "field": "gold_patch"},
-                            "label": "Gold Standard Patch"
-                        }
-                    ]
+            "data": {
+                "type": "markdown"
+            },
+            "output": {
+                "type": "vstack",
+                "keys": {
+                    "status": {
+                        "type": "text",
+                        "label": "Status"
+                    },
+                    "patch": {
+                        "type": "code",
+                        "label": "Generated Patch"
+                    },
+                    "gold_patch": {
+                        "type": "code",
+                        "label": "Gold Standard Patch"
+                    }
                 }
-            ],
+            },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",
         public=True,

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,28 +35,30 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "markdown",
-                "content": {"type": "data", "field": "problem_statement"}
+                "type": "list",
+                "elements": {
+                    "type": "markdown"
+                }
             },
             "output": {
-                "type": "vstack",
-                "elements": [
-                    {
-                        "type": "text",
-                        "content": {"type": "output", "field": "status"},
-                        "label": "Status"
-                    },
-                    {
-                        "type": "code",
-                        "content": {"type": "output", "field": "patch"},
-                        "label": "Generated Patch"
-                    },
-                    {
-                        "type": "code",
-                        "content": {"type": "data", "field": "gold_patch"},
-                        "label": "Gold Standard Patch"
+                "type": "list",
+                "elements": {
+                    "type": "vstack",
+                    "keys": {
+                        "status": {
+                            "type": "text",
+                            "label": "Status"
+                        },
+                        "patch": {
+                            "type": "code",
+                            "label": "Generated Patch"
+                        },
+                        "gold_patch": {
+                            "type": "code",
+                            "label": "Gold Standard Patch"
+                        }
                     }
-                ]
+                }
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,26 +35,27 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "markdown",
-                "elements": [
-                    {
-                        "type": "text"
-                    }
-                ]
+                "type": "list",
+                "elements": {
+                    "type": "markdown"
+                }
             },
             "output": {
-                "type": "vstack",
-                "elements": [
-                    {
-                        "type": "text"
-                    },
-                    {
-                        "type": "code"
-                    },
-                    {
-                        "type": "code"
+                "type": "list",
+                "elements": {
+                    "type": "vstack",
+                    "keys": {
+                        "status": {
+                            "type": "text"
+                        },
+                        "patch": {
+                            "type": "code"
+                        },
+                        "gold_patch": {
+                            "type": "code"
+                        }
                     }
-                ]
+                }
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -36,7 +36,6 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         view={
             "data": {"type": "markdown"},
             "label": {"type": "text"},
-            "patch_length": {"type": "number", "label": "Gold Patch Length"},
             "gold_patch": {"type": "code", "label": "Gold Standard Patch"},
             "output": {
                 "type": "vstack",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -37,7 +37,8 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
             "data": {
                 "type": "list",
                 "elements": {
-                    "type": "markdown"
+                    "type": "markdown",
+                    "content": {"type": "data", "field": "problem_statement"}
                 }
             },
             "output": {
@@ -46,13 +47,16 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
                     "type": "vstack",
                     "keys": {
                         "status": {
-                            "type": "text"
+                            "type": "text",
+                            "content": {"type": "output", "field": "status"}
                         },
                         "patch": {
-                            "type": "code"
+                            "type": "code",
+                            "content": {"type": "output", "field": "patch"}
                         },
                         "gold_patch": {
-                            "type": "code"
+                            "type": "code",
+                            "content": {"type": "data", "field": "gold_patch"}
                         }
                     }
                 }

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,21 +35,26 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "markdown"
+                "type": "markdown",
+                "elements": [
+                    {
+                        "type": "text"
+                    }
+                ]
             },
             "output": {
                 "type": "vstack",
-                "keys": {
-                    "status": {
+                "elements": [
+                    {
                         "type": "text"
                     },
-                    "patch": {
+                    {
                         "type": "code"
                     },
-                    "gold_patch": {
+                    {
                         "type": "code"
                     }
-                }
+                ]
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -34,26 +34,14 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
     viz_project = viz_client.create_project(
         name="SWE-bench Leaderboard",
         view={
-            "data": {
-                "type": "markdown",
-                "content": "problem_statement"
-            },
+            "data": {"type": "markdown"},
+            "label": {"type": "text"},
             "output": {
                 "type": "vstack",
-                "elements": [
-                    {
-                        "type": "text",
-                        "content": "status"
-                    },
-                    {
-                        "type": "code",
-                        "content": "patch"
-                    },
-                    {
-                        "type": "code",
-                        "content": "gold_patch"
-                    }
-                ]
+                "keys": {
+                    "status": {"type": "text", "label": "Status"},
+                    "patch": {"type": "code"},
+                }
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,28 +35,19 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "list",
-                "elements": {
-                    "type": "markdown"
-                }
+                "type": "markdown"
             },
             "output": {
-                "type": "list",
-                "elements": {
-                    "type": "vstack",
-                    "keys": {
-                        "status": {
-                            "type": "text",
-                            "label": "Status"
-                        },
-                        "patch": {
-                            "type": "code",
-                            "label": "Generated Patch"
-                        },
-                        "gold_patch": {
-                            "type": "code",
-                            "label": "Gold Standard Patch"
-                        }
+                "type": "vstack",
+                "keys": {
+                    "status": {
+                        "type": "text"
+                    },
+                    "patch": {
+                        "type": "code"
+                    },
+                    "gold_patch": {
+                        "type": "code"
                     }
                 }
             },

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,22 +35,23 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "markdown"
+                "type": "markdown",
+                "content": "problem_statement"
             },
             "output": {
                 "type": "vstack",
                 "elements": [
                     {
                         "type": "text",
-                        "content": {"type": "output", "field": "status"}
+                        "content": "status"
                     },
                     {
                         "type": "code",
-                        "content": {"type": "output", "field": "patch"}
+                        "content": "patch"
                     },
                     {
                         "type": "code",
-                        "content": {"type": "data", "field": "gold_patch"}
+                        "content": "gold_patch"
                     }
                 ]
             },

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -34,16 +34,32 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
     viz_project = viz_client.create_project(
         name="SWE-bench Leaderboard",
         view={
-            "data": {"type": "markdown"},
-            "label": {"type": "text"},
-            "output": {
-                "type": "vstack",
-                "keys": {
-                    "status": {"type": "text", "label": "Status"},
-                    "patch": {"type": "code", "label": "Generated Patch"},
-                    "gold_patch": {"type": "code", "label": "Gold Standard Patch"}
+            "elements": [
+                {
+                    "type": "markdown",
+                    "content": {"type": "data", "field": "problem_statement"}
+                },
+                {
+                    "type": "vstack",
+                    "elements": [
+                        {
+                            "type": "text",
+                            "content": {"type": "output", "field": "status"},
+                            "label": "Status"
+                        },
+                        {
+                            "type": "code",
+                            "content": {"type": "output", "field": "patch"},
+                            "label": "Generated Patch"
+                        },
+                        {
+                            "type": "code",
+                            "content": {"type": "data", "field": "gold_patch"},
+                            "label": "Gold Standard Patch"
+                        }
+                    ]
                 }
-            },
+            ],
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",
         public=True,

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,31 +35,24 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "list",
-                "elements": {
-                    "type": "markdown",
-                    "content": {"type": "data", "field": "problem_statement"}
-                }
+                "type": "markdown"
             },
             "output": {
-                "type": "list",
-                "elements": {
-                    "type": "vstack",
-                    "keys": {
-                        "status": {
-                            "type": "text",
-                            "content": {"type": "output", "field": "status"}
-                        },
-                        "patch": {
-                            "type": "code",
-                            "content": {"type": "output", "field": "patch"}
-                        },
-                        "gold_patch": {
-                            "type": "code",
-                            "content": {"type": "data", "field": "gold_patch"}
-                        }
+                "type": "vstack",
+                "elements": [
+                    {
+                        "type": "text",
+                        "content": {"type": "output", "field": "status"}
+                    },
+                    {
+                        "type": "code",
+                        "content": {"type": "output", "field": "patch"}
+                    },
+                    {
+                        "type": "code",
+                        "content": {"type": "data", "field": "gold_patch"}
                     }
-                }
+                ]
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -36,12 +36,12 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         view={
             "data": {"type": "markdown"},
             "label": {"type": "text"},
-            "gold_patch": {"type": "code", "label": "Gold Standard Patch"},
             "output": {
                 "type": "vstack",
                 "keys": {
                     "status": {"type": "text", "label": "Status"},
                     "patch": {"type": "code", "label": "Generated Patch"},
+                    "gold_patch": {"type": "code", "label": "Gold Standard Patch"}
                 }
             },
         },

--- a/scripts/leaderboard_to_zeno.py
+++ b/scripts/leaderboard_to_zeno.py
@@ -35,24 +35,28 @@ def main(split: Split, zeno_api_key: str | None, top_n: int | None) -> None:
         name="SWE-bench Leaderboard",
         view={
             "data": {
-                "type": "markdown"
+                "type": "markdown",
+                "content": {"type": "data", "field": "problem_statement"}
             },
             "output": {
                 "type": "vstack",
-                "keys": {
-                    "status": {
+                "elements": [
+                    {
                         "type": "text",
+                        "content": {"type": "output", "field": "status"},
                         "label": "Status"
                     },
-                    "patch": {
+                    {
                         "type": "code",
+                        "content": {"type": "output", "field": "patch"},
                         "label": "Generated Patch"
                     },
-                    "gold_patch": {
+                    {
                         "type": "code",
+                        "content": {"type": "data", "field": "gold_patch"},
                         "label": "Gold Standard Patch"
                     }
-                }
+                ]
             },
         },
         description=f"SWE-bench leaderboard (as of {current_time}) performance analysis, by entry.",


### PR DESCRIPTION
This PR adds a `times_resolved` column to the dataset DataFrame in the Zeno visualization. This column tracks how many systems successfully solved each instance, making it easier to analyze which problems are commonly solved or particularly challenging.

Changes:
- Added resolution count tracking before dataset upload
- Added `times_resolved` column to dataset DataFrame
- Removed view specification for the column to avoid invalid view errors

This allows us to do analyses like finding places where our system failed despite most others succeeding.